### PR TITLE
fix: steam crash

### DIFF
--- a/Assets/SteamSample/SteamRelayConnection.cs
+++ b/Assets/SteamSample/SteamRelayConnection.cs
@@ -39,6 +39,11 @@ namespace SteamSample
 
         public void SendMessageToClient(ArraySegment<byte> packetData)
         {
+            if (!SteamClient.IsValid)
+            {
+                return;
+            }
+
             // Throttling is already handled by coherence
             var sendType = SendType.Unreliable | SendType.NoNagle;
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/engine-group-5fb3b64dabadec002057e6f2/issues/gh/coherence/unity/4772

I am not 100% sure this solves the problem. Haven't had a crash for a while now but they are somewhat rare. 
Regardless, I don't think this guard clause will hurt.