### PR TITLE
fix: steam lib crash due to send after deinit

### DIFF
--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -101,6 +101,11 @@ namespace SteamSample
         void OnDisable()
         {
             // Cleanup
+            if (bridge)
+            {
+                bridge.Disconnect();
+            }
+            
             Shutdown();
             SteamClient.Shutdown();
         }


### PR DESCRIPTION
Fixes coherence/unity#4772

Attempt to send data via Steam after `SteamClient.Shutdown()` results in segfault 100% of the time.

This change makes sure that in case of `SteamManager` being disabled/destroyed we first disconnect the bridge and thus disable the relay manager, so it will stop updating.