### PR TITLE
fix: error message when connecting with same steam account

### DIFF
--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -157,6 +157,11 @@ namespace SteamSample
                 throw new Exception($"You need to enter a host SteamId #{steamIdToJoin} in the inspector or CLI");
             }
 
+            if (steamIdToJoin == SteamClient.SteamId)
+            {
+                throw new Exception($"Failed to join host #{steamIdToJoin} from client #{SteamClient.SteamId}. You need to join from a separate Steam account and machine.");
+            }
+
             // Make sure we are not already in a game or joining a game
             if (bridge.IsConnected || bridge.IsConnecting)
             {


### PR DESCRIPTION
Steam SDK will throw an ArgumentException: Invalid Connection if you try to connect to a host with the same steam account.

It is not obvious to developers that you need separate accounts logged in on separate machines to test multiplayer with steam, so this error message should help them figure that out.

https://discord.com/channels/618322516762558466/778210555344191498/1244918761304100876