### PR TITLE
fix: SteamManager fail join game handling

### DIFF
--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -173,7 +173,7 @@ namespace SteamSample
             SteamId serverId = default;
 
             // Get the game server SteamID for that lobby and join
-            if(!lobby.GetGameServer(ref ip, ref port, ref serverId))
+            if (!lobby.GetGameServer(ref ip, ref port, ref serverId))
             {
                 Debug.LogError($"Failed to get game server from lobby {lobby.Id}.");
                 return;

--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -6,12 +6,10 @@ using Coherence;
 using Coherence.Connection;
 using Coherence.Toolkit;
 using Coherence.Toolkit.ReplicationServer;
+using Coherence.Transport;
 using Steamworks;
 using Steamworks.Data;
 using UnityEngine;
-using Coherence.Log;
-using Coherence.Transport;
-using Logger = Coherence.Log.Logger;
 
 namespace SteamSample
 {
@@ -177,20 +175,20 @@ namespace SteamSample
             // Get the game server SteamID for that lobby and join
             if(!lobby.GetGameServer(ref ip, ref port, ref serverId))
             {
-	            Debug.LogError($"Failed to get game server from lobby {lobby.Id}.");
-	            return;
+                Debug.LogError($"Failed to get game server from lobby {lobby.Id}.");
+                return;
             }
 
             lobby.Join();
             activeLobby = lobby;
             try
             {
-	            JoinGame(serverId);
+                JoinGame(serverId);
             }
             catch
             {
-	            activeLobby = null;
-	            throw;
+                activeLobby = null;
+                throw;
             }
         }
 

--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -136,7 +136,7 @@ namespace SteamSample
             }
         }
 
-        public void JoinGame(SteamId? steamId = null)
+        public void JoinGame(SteamId? steamId)
         {
             if (steamId.HasValue)
             {
@@ -175,15 +175,22 @@ namespace SteamSample
             SteamId serverId = default;
 
             // Get the game server SteamID for that lobby and join
-            if (lobby.GetGameServer(ref ip, ref port, ref serverId))
+            if(!lobby.GetGameServer(ref ip, ref port, ref serverId))
             {
-                lobby.Join();
-                activeLobby = lobby;
-                JoinGame(serverId);
+	            Debug.LogError($"Failed to get game server from lobby {lobby.Id}.");
+	            return;
             }
-            else
+
+            lobby.Join();
+            activeLobby = lobby;
+            try
             {
-                Debug.LogError($"Failed to get game server from lobby {lobby.Id}.");
+	            JoinGame(serverId);
+            }
+            catch
+            {
+	            activeLobby = null;
+	            throw;
             }
         }
 


### PR DESCRIPTION
## Addresses
https://app.zenhub.com/workspaces/sdk-team-5fff1025e6ab9f001e525a92/issues/gh/coherence/unity/8533

## Fixed
- SteamManager.JoinGame will now clear active lobby if JoinGame fails with an exception. This way the sample UI won't claim that the player is in a lobby which they in reality failed to join.
- Fixed issue with SteamManager defining a JoinGame method with no parameters and a JoinGame method with only an optional parameter, resulting in a warning about method hiding.