### PR TITLE
fix: Remove unused logger causing warnings

### DIFF
--- a/Assets/SteamSample/SteamLobbyUI.cs
+++ b/Assets/SteamSample/SteamLobbyUI.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using Steamworks;
 using Steamworks.Data;
 using UnityEngine;
-using Coherence.Log;
-using Logger = Coherence.Log.Logger;
 
 namespace SteamSample
 {
@@ -14,16 +12,11 @@ namespace SteamSample
         public bool showLobbyUI = true;
 
         SteamManager steamManager;
-        List<Lobby> lobbies = new List<Lobby>();
+        List<Lobby> lobbies = new();
         Vector2 scrollBarPosition;
         bool refreshInProgress;
 
-        private static readonly Logger logger = Log.GetLogger<SteamLobbyUI>();
-
-        void Awake()
-        {
-            steamManager = GetComponent<SteamManager>();
-        }
+        void Awake() => steamManager = GetComponent<SteamManager>();
 
         void OnGUI()
         {


### PR DESCRIPTION
Removed initialization of logger that was never used from SteamLobbyUI, which was triggering the warning 'Logger was initialized before its settings were loaded.'