### PR TITLE
fix: facepunch OSX lib import settings

### DIFF
--- a/Assets/Plugins/Facepunch.Steamworks.2.4.1/Facepunch.Steamworks.Posix.dll.meta
+++ b/Assets/Plugins/Facepunch.Steamworks.2.4.1/Facepunch.Steamworks.Posix.dll.meta
@@ -17,15 +17,15 @@ PluginImporter:
       enabled: 0
       settings:
         Exclude Editor: 0
-        Exclude Linux64: 0
+        Exclude Linux64: 1
         Exclude OSXUniversal: 0
-        Exclude WebGL: 0
+        Exclude WebGL: 1
         Exclude Win: 1
         Exclude Win64: 1
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
@@ -34,7 +34,7 @@ PluginImporter:
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
-        OS: AnyOS
+        OS: OSX
   - first:
       Facebook: Win
     second:
@@ -50,9 +50,9 @@ PluginImporter:
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
@@ -74,7 +74,7 @@ PluginImporter:
   - first:
       WebGL: WebGL
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Windows Store Apps: WindowsStoreApps


### PR DESCRIPTION
The Facepunch.Steamworks.Posix.dll had wrong import settings, which made it conflict with Windows version of the library.