### PR TITLE
Fix/disconnect UI

### DIFF
--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -125,8 +125,17 @@ namespace SteamSample
         {
             if (activeLobby.HasValue)
             {
-                activeLobby.Value.Leave();
+                var lobby = activeLobby.Value;
                 activeLobby = null;
+
+                try
+                {
+                    lobby.Leave();
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogException(exception);
+                }
             }
 
             if (SteamServer.IsValid)
@@ -266,10 +275,6 @@ namespace SteamSample
             {
                 StopReplicationServer();
             }
-
-            // Clear state right away instead of waiting on the async onDisconnected
-            // callback, so the UI reflects the disconnect immediately.
-            Shutdown();
         }
 
         void OnConnected(CoherenceBridge _)

--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -266,7 +266,13 @@ namespace SteamSample
         {
             if (!bridge.IsConnected && !bridge.IsConnecting)
             {
-                throw new Exception("Failed to disconnect, CoherenceBridge is not connected");
+                // The connection can die before ever reaching "Connected" (e.g. a join
+                // attempt against a stale/closed lobby). In that case the underlying
+                // transport may never raise onDisconnected/onConnectionError, so Shutdown()
+                // never runs and local state (activeLobby, etc.) is left stale. Reconcile
+                // it here instead of leaving the UI stuck.
+                Shutdown();
+                return;
             }
 
             bridge.Disconnect();
@@ -274,6 +280,14 @@ namespace SteamSample
             if (replicationServer != null)
             {
                 StopReplicationServer();
+            }
+
+            // If the connection never reached "Connected" (e.g. it was still mid-handshake),
+            // bridge.Disconnect() closes it synchronously without ever raising onDisconnected.
+            // Don't wait on an event that will never come - reconcile now.
+            if (!bridge.IsConnected && !bridge.IsConnecting)
+            {
+                Shutdown();
             }
         }
 

--- a/Assets/SteamSample/SteamManager.cs
+++ b/Assets/SteamSample/SteamManager.cs
@@ -266,6 +266,10 @@ namespace SteamSample
             {
                 StopReplicationServer();
             }
+
+            // Clear state right away instead of waiting on the async onDisconnected
+            // callback, so the UI reflects the disconnect immediately.
+            Shutdown();
         }
 
         void OnConnected(CoherenceBridge _)


### PR DESCRIPTION
Fix for https://github.com/coherence/steam-integration-sample/issues/36 


Root cause: SteamManager.Shutdown() cleared activeLobby after calling activeLobby.Value.Leave() — if Leave() threw, the null-out never ran and the UI stayed stuck on "Active lobby / Disconnect" forever.

A second issue only affected joining clients: if the connection died before ever reaching "Connected" (e.g. joining a stale lobby), the coherence SDK's Brisk.Disconnect() closes the connection without firing onDisconnected, so Shutdown() never got called at all — no event, no cleanup.

Changes, all in Assets/SteamSample/SteamManager.cs, no SDK changes:

Shutdown() — clear activeLobby before calling Leave(), and catch/log any exception from Leave() instead of letting it block the reset.
Disconnect() — if the bridge is already disconnected/not-connecting when pressed, call Shutdown() directly instead of throwing.
Disconnect() — after calling bridge.Disconnect(), re-check connection state immediately and call Shutdown() if it silently dropped without firing the event (covers the mid-handshake case in one press instead of needing two).

The normal, fully-connected disconnect flow still goes through the real onDisconnected event as designed — these are recovery paths for the cases where that event doesn't fire.